### PR TITLE
Fix SQL syntax error in installation sql.

### DIFF
--- a/com_languagepack/admin/sql/install/install_mysql.sql
+++ b/com_languagepack/admin/sql/install/install_mysql.sql
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `#__languagepack_applications` (
   `ars_visual_group` bigint(20) NOT NULL,
   `s3_path` VARCHAR(100) NOT NULL,
   PRIMARY KEY (`id`),
-  CONSTRAINT `fk_languagepack_languages_ars_environment` FOREIGN KEY (`ars_environment`) REFERENCES `#__ars_environments` (`id`)  ON DELETE NO ACTION
+  CONSTRAINT `fk_languagepack_languages_ars_environment` FOREIGN KEY (`ars_environment`) REFERENCES `#__ars_environments` (`id`)  ON DELETE NO ACTION,
   CONSTRAINT `fk_languagepack_languages_ars_visual_group` FOREIGN KEY (`ars_visual_group`) REFERENCES `#__ars_vgroups` (`id`)  ON DELETE NO ACTION
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 


### PR DESCRIPTION
As reported by @infograf768 in maintainer chat in Glip:

```
Warning
JInstaller: :Install: Error SQL You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'CONSTRAINT `fk_languagepack_languages_ars_visual_group` FOREIGN KEY (`ars_visual' at line 11
Extension JLIB_INSTALLER_DISCOVER_INSTALL: SQL error processing query: DB function failed with error number 1064
You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'CONSTRAINT `fk_languagepack_languages_ars_visual_group` FOREIGN KEY (`ars_visual' at line 11
```