### PR TITLE
Adds the export XML for languages, and language details per cms version

### DIFF
--- a/com_languagepack/site/controller.php
+++ b/com_languagepack/site/controller.php
@@ -40,7 +40,7 @@ class LanguagepackController extends BaseController
 	 */
 	public function display($cachable = true, $urlparams = array())
 	{
-		$urlparams += array('langid' => 'INT', 'application_id' => 'INT');
+		$urlparams += array('langid' => 'INT', 'application_id' => 'INT', 'cms_version' => 'INT', 'language_code' => 'STRING');
 
 		$vName = $this->input->getCmd('view', $this->default_view);
 

--- a/com_languagepack/site/language/en-GB/en-GB.com_languagepack.ini
+++ b/com_languagepack/site/language/en-GB/en-GB.com_languagepack.ini
@@ -21,6 +21,11 @@ COM_LANGUAGEPACK_RELEASE_JOOMLA_VERSION_LABEL="Which version of Joomla is this p
 COM_LANGUAGEPACK_RELEASE_LANGUAGE_PACK_VERSION_LABEL="Specify the language pack version for this Joomla Version"
 COM_LANGUAGEPACK_RELEASE_UPLOAD_PACK="Upload Language Pack"
 
+; Export XML API
+COM_LANGUAGE_PACK_EXPORT_CMS_VERSION_REQUIRED="CMS version required for export"
+COM_LANGUAGE_PACK_EXPORT_CMS_VERSION_NOT_FOUND="CMS version branch not found"
+COM_LANGUAGE_PACK_EXPORT_NO_DATA_FOUND="No Data Found"
+
 ; Messages when uploading a pack
 COM_LANGUAGEPACK_ARS_RELEASE_ALREADY_EXISTS="Release has already been created."
 COM_LANGUAGEPACK_ARS_RELEASE_ITEM_ALREADY_EXISTS="Release ZIP has already been created in the release system."

--- a/com_languagepack/site/models/export.php
+++ b/com_languagepack/site/models/export.php
@@ -1,0 +1,338 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_languagepack
+ *
+ * @copyright   Copyright (C) 2020 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use FOF30\Container\Container;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\MVC\Model\ListModel;
+
+/**
+ * Export model class.
+ *
+ * @since  1.0
+ */
+class LanguagepackModelExport extends ListModel
+{
+	/**
+	 * Maps the API Path
+	 *
+	 * (which we keep consistent with existing breakdown etc endpoints) to the language pack
+	 * component application ID and the corresponding ARS Menu ID for that language for nice SEF URLs.
+	 *
+	 * @var    Array
+	 * @since  1.0
+	 */
+	public $mapping
+		= [
+			10 => [
+				'application_id' => 1,
+				'menu_id'        => 678,
+				'filename'       => 'translationlist_1',
+				'folder'         => 'details1',
+				'target'         => '1.0'
+			],
+			15 => [
+				'application_id' => 2,
+				'menu_id'        => 677,
+				'filename'       => 'translationlist_1_5',
+				'folder'         => 'details1_5',
+				'target'         => '1.5'
+			],
+			25 => [
+				'application_id' => 3,
+				'menu_id'        => 676,
+				'filename'       => 'translationlist',
+				// this should have been 'translationlist_2_5'
+				'folder'         => 'details',
+				// this should have been 'details2_5'
+				'target'         => '2.5'
+			],
+			30 => [
+				'application_id' => 4,
+				'menu_id'        => 674,
+				'filename'       => 'translationlist_3',
+				'folder'         => 'details3',
+				'target'         => '3.([0123456789]|10)'
+			],
+			40 => [
+				'application_id' => 5,
+				'menu_id'        => 675,
+				'filename'       => 'translationlist_4',
+				'folder'         => 'details4',
+				'target'         => '4.0'
+			],
+		];
+
+	/**
+	 * Create the export document for a language xml request.
+	 *
+	 * @param   string  $type  The request TYPE to process
+	 *
+	 * @return  array|boolean  A array for a successful export or boolean false on an error
+	 *
+	 * @since  1.0
+	 */
+	public function collectDataForExportRequest($cmsVersion = null,
+		$languageCode = null
+	) {
+		$cmsVersion   = !empty($cmsVersion) ? $cmsVersion
+			: (string) $this->getState($this->getName() . '.cms_version');
+		$languageCode = !empty($languageCode) ? $languageCode
+			: (string) $this->getState($this->getName() . '.language_code');
+
+		// we must have a CMS version
+		if (!$cmsVersion)
+		{
+			$this->setError(Text::_('CMS version required for export'));
+
+			return false;
+		}
+		elseif (!isset($this->mapping[$cmsVersion]))
+		{
+			$this->setError(Text::_('CMS version branch not found'));
+
+			return false;
+		}
+
+		if ($languageCode)
+		{
+			return $this->getLanguageBreakdown($cmsVersion, $languageCode);
+		}
+
+		return $this->getLanguagesByversion($cmsVersion);
+	}
+
+	/**
+	 * Get the breakdown of a language.
+	 *
+	 * @param   string  $cmsVersion    The request CMS Version to retrieve
+	 * @param   string  $languageCode  The request Language Code to retrieve
+	 *
+	 * @return  array|boolean  A array for a successful export or boolean false on an error
+	 *
+	 * @since  1.0
+	 */
+	protected function getLanguageBreakdown($cmsVersion, $languageCode)
+	{
+		$db           = \JFactory::getDbo();
+		$arsContainer = Container::getInstance('com_ars');
+
+		$query = $db->getQuery(true)
+			->select($db->quoteName('a.ars_category'))
+			->from($db->quoteName('#__languagepack_languages', 'a'))
+			->rightJoin(
+				$db->quoteName('#__languagepack_applications', 'b') . ' ON '
+				. $db->quoteName('b.id') . ' = ' . $db->quoteName(
+					'a.application_id'
+				)
+			)
+			->where(
+				$db->quoteName('a.application_id') . ' = '
+				. (int) $this->mapping[$cmsVersion]['application_id']
+			)
+			->where(
+				$db->quoteName('a.lang_code') . ' = ' . $db->quote(
+					$languageCode
+				)
+			)
+			->where('a.state = ' . 1)
+			->where('b.state = ' . 1);
+
+		$db->setQuery($query);
+		$arsCategoryId = $db->loadResult();
+
+		if (!$arsCategoryId)
+		{
+			return false;
+		}
+
+		/** @var \Akeeba\ReleaseSystem\Admin\Model\Releases $model */
+		$model = $arsContainer->factory->model('Releases')->tmpInstance();
+
+		/** @var \FOF30\Model\DataModel\Collection $releases */
+		$releases = $model->reset(true)
+			->category_id(['value' => $arsCategoryId, 'method' => 'exact'])
+			->published(1)
+			->access_user($arsContainer->platform->getUser()->id)
+			->with(['items', 'category'])
+			->get(true);
+
+		$totalReleases = $releases->count();
+		$versions      = [];
+		$rootURL       = rtrim(\JUri::root(), '/');
+		$target        = $this->mapping[$cmsVersion]['target'];
+
+		if ($totalReleases)
+		{
+			/** @var \Akeeba\ReleaseSystem\Admin\Model\Releases $release */
+			foreach ($releases as $release)
+			{
+				$version = [
+					'name'        => $release->category->title, // not ideal
+					'description' => $release->description,
+					'version'     => $release->version,
+					'element'     => 'pkg_' . $languageCode,
+					'type'        => 'package',
+					'target'      => $target,
+					'downloads'   => [],
+				];
+
+				foreach ($release->items as $item)
+				{
+					if ($item->type !== 'file')
+					{
+						continue;
+					}
+
+					$downloadUrl = \JRoute::link(
+						'site',
+						'index.php?option=com_ars&view=Item&task=download&format=raw&id='
+						. $item->id . '&Itemid='
+						. $this->mapping[$cmsVersion]['menu_id']
+					);
+
+					// We use the same structure for response as in the CMS signatures endpoint. Yay for API Consistency!
+					$version['downloads'][] = [
+						'url'    => $rootURL . $downloadUrl,
+						'type'   => 'full',
+						'format' => 'zip',
+						// the type and format values not found in the item object
+						// we could pull this from the filename, but not ideal?
+						'md5'    => $item->md5,
+						'sha1'   => $item->sha1,
+						'sha256' => $item->sha256,
+						'sha384' => $item->sha384,
+						'sha512' => $item->sha512
+					];
+				}
+
+				$versions[] = $version;
+			}
+
+			$returnedData = [
+				'total'    => $totalReleases,
+				'versions' => $versions,
+			];
+
+			return $returnedData;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the breakdown of a language.
+	 *
+	 * @param   string  $cmsVersion  The request CMS Version to retrieve
+	 *
+	 * @return  array|boolean  A array for a successful export or boolean false on an error
+	 *
+	 * @since  1.0
+	 */
+	protected function getLanguagesByversion($cmsVersion)
+	{
+		$model = \JModelLegacy::getInstance(
+			'Application', 'LanguagepackModel', array('ignore_request' => true)
+		);
+		$model->setState(
+			'application_id', $this->mapping[$cmsVersion]['application_id']
+		);
+		$items        = $model->getItems();
+		$results      = [];
+		$arsContainer = Container::getInstance('com_ars');
+
+		/** @var \Akeeba\ReleaseSystem\Admin\Model\Releases $model */
+		$model = $arsContainer->factory->model('Releases')->tmpInstance();
+
+		$model->reset(true)
+			->published(1)
+			->latest(true)
+			->access_user($arsContainer->platform->getUser()->id)
+			->with(['items', 'category']);
+
+		/** @var \FOF30\Model\DataModel\Collection $releases */
+		$releases = $model->get(true)->filter(
+			function ($item) {
+				return \Akeeba\ReleaseSystem\Site\Helper\Filter::filterItem(
+					$item, true
+				);
+			}
+		);
+
+		$categoryLatest = [];
+
+		if ($releases->count())
+		{
+			/** @var \Akeeba\ReleaseSystem\Admin\Model\Releases $release */
+			foreach ($releases as $release)
+			{
+				$categoryLatest[$release->category->id] = $release->getData();
+			}
+		}
+
+		foreach ($items as $item)
+		{
+			// If we don't have an available release on ARS don't return it...
+			// In the future we may want to make this access level driven
+			if (!array_key_exists($item->ars_category, $categoryLatest))
+			{
+				continue;
+			}
+
+			$result = [
+				'name'          => $item->name,
+				'languageCode'  => $item->lang_code,
+				'latestVersion' => $categoryLatest[$item->ars_category]['version'],
+				'url'           => 'https://update.joomla.org/language/'
+					. $this->mapping[$cmsVersion]['folder'] . '/'
+					. $item->lang_code . '_details.xml'
+			];
+
+			$results[] = $result;
+		}
+
+		$returnedData = [
+			'total'     => count($results),
+			'languages' => $results,
+		];
+
+		return $returnedData;
+	}
+
+	/**
+	 * Method to auto-populate the model state.
+	 *
+	 * @param   string  $ordering   An optional ordering field.
+	 * @param   string  $direction  An optional direction (asc|desc).
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	protected function populateState($ordering = null, $direction = null)
+	{
+		$app = Factory::getApplication();
+		$this->setState('params', $app->getParams());
+		$this->setState(
+			$this->getName() . '.cms_version',
+			$app->input->getInt('cms_version')
+		);
+		$this->setState(
+			$this->getName() . '.language_code',
+			$app->input->getCmd('language_code', null)
+		);
+
+		parent::populateState($ordering, $direction);
+
+		// Override the list model to show all languages in the frontend
+		$this->setState('list.limit', 0);
+	}
+}

--- a/com_languagepack/site/models/export.php
+++ b/com_languagepack/site/models/export.php
@@ -91,13 +91,13 @@ class LanguagepackModelExport extends ListModel
 		// we must have a CMS version
 		if (!$cmsVersion)
 		{
-			$this->setError(Text::_('CMS version required for export'));
+			$this->setError(Text::_('COM_LANGUAGE_PACK_EXPORT_CMS_VERSION_REQUIRED'));
 
 			return false;
 		}
 		elseif (!isset($this->mapping[$cmsVersion]))
 		{
-			$this->setError(Text::_('CMS version branch not found'));
+			$this->setError(Text::_('COM_LANGUAGE_PACK_EXPORT_CMS_VERSION_NOT_FOUND'));
 
 			return false;
 		}

--- a/com_languagepack/site/router.php
+++ b/com_languagepack/site/router.php
@@ -57,6 +57,10 @@ class LanguagepackRouter extends RouterView
 
 		$this->registerView($newPack);
 
+		$export = (new RouterViewConfiguration('export'))
+			->setKey('cms_version');
+		$this->registerView($export);
+
 		parent::__construct($app, $menu);
 
 		$this->attachRule(new MenuRules($this));

--- a/com_languagepack/site/views/export/view.xml.php
+++ b/com_languagepack/site/views/export/view.xml.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  com_languagepack
+ *
+ * @copyright   Copyright (C) 2020 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\MVC\View\HtmlView;
+
+/**
+ * Export view class
+ *
+ * @since  1.0
+ *
+ * @property-read   \Joomla\CMS\Document\XmlDocument $document
+ */
+class LanguagepackViewExport extends HtmlView
+{
+	/**
+	 * Execute and display a template script.
+	 *
+	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
+	 *
+	 * @return  mixed  A string if successful, otherwise an Error object.
+	 */
+	public function display($tpl = null)
+	{
+		/** @var LanguagepackModelExport $model */
+		$model = $this->getModel();
+
+		$exportData = $model->collectDataForExportRequest();
+
+		// Check for errors.
+		if (count($errors = $this->get('Errors')))
+		{
+			throw new Exception(implode("\n", $errors), 500);
+		}
+		elseif (!$exportData)
+		{
+			throw new Exception('No Data Found', 500);
+		}
+
+		$cmsVersion   = $model->getState(
+			$model->getName() . '.cms_version'
+		);
+		$languageCode = $model->getState(
+			$model->getName() . '.language_code'
+		);
+
+		// This document should always be downloaded
+		$this->document->setDownload(true);
+
+		// Set the document name
+		if ($languageCode)
+		{
+			$this->document->setName(
+				$languageCode . '_details'
+			);
+
+			echo $this->renderLanguageAsXml($exportData['versions']);
+		}
+		else
+		{
+			$this->document->setName(
+				$model->mapping[$cmsVersion]['filename']
+			);
+
+			echo $this->renderLanguagesAsXml($exportData['languages']);
+		}
+
+	}
+
+	/**
+	 * Render the languages as a XML document.
+	 *
+	 * @param   array  $exportData  The data to be exported.
+	 *
+	 * @return  string
+	 *
+	 * @since  1.0
+	 */
+	protected function renderLanguagesAsXml(array $exportData)
+	{
+		$export = new SimpleXMLElement(
+			'<?xml version="1.0" encoding="utf-8"?><extensionset />'
+		);
+		$export->addAttribute('name', 'Accredited Joomla! Translations');
+		$export->addAttribute(
+			'description', 'Accredited Joomla! Translations Updates'
+		);
+
+		foreach ($exportData as $language)
+		{
+			$xmlLang = $export->addChild('extension');
+			$xmlLang->addAttribute('name', $language['name']);
+			$xmlLang->addAttribute('element', $language['languageCode']);
+			$xmlLang->addAttribute('type', 'package');
+			$xmlLang->addAttribute('version', $language['latestVersion']);
+			$xmlLang->addAttribute('detailsurl', $language['url']);
+		}
+
+		$dom = new DOMDocument;
+		$dom->loadXML($export->asXML());
+		$dom->formatOutput = true;
+
+		return $dom->saveXML();
+	}
+
+	/**
+	 * Render a language details as a XML document.
+	 *
+	 * @param   array  $exportData  The data to be exported.
+	 *
+	 * @return  string
+	 *
+	 * @since  1.0
+	 */
+	protected function renderLanguageAsXml(array $exportData)
+	{
+		$export = new SimpleXMLElement(
+			'<?xml version="1.0" encoding="utf-8"?><updates />'
+		);
+
+		foreach ($exportData as $update)
+		{
+			$xmlLang              = $export->addChild('update');
+			$xmlLang->name        = $update['name'];
+			$xmlLang->description = $update['description'];
+			$xmlLang->element     = $update['element'];
+			$xmlLang->type        = $update['type'];
+			$xmlLang->version     = $update['version'];
+
+			$xmlDownLoad = $xmlLang->addChild('downloads');
+
+			foreach ($update['downloads'] as $download)
+			{
+				$xmlDownLoad->downloadurl = $download['url'];
+
+				$xmlDownLoad->downloadurl->addAttribute(
+					'type', $download['type']
+				);
+				$xmlDownLoad->downloadurl->addAttribute(
+					'format', $download['format']
+				);
+				$xmlDownLoad->downloadurl->addAttribute(
+					'md5', $download['md5']
+				);
+				$xmlDownLoad->downloadurl->addAttribute(
+					'sha1', $download['sha1']
+				);
+				$xmlDownLoad->downloadurl->addAttribute(
+					'sha256', $download['sha256']
+				);
+				$xmlDownLoad->downloadurl->addAttribute(
+					'sha384', $download['sha384']
+				);
+				$xmlDownLoad->downloadurl->addAttribute(
+					'sha512', $download['sha512']
+				);
+			}
+
+			$xmlPlatform = $xmlLang->addChild('targetplatform');
+			$xmlPlatform->addAttribute('name', 'joomla');
+			$xmlPlatform->addAttribute('version', $update['target']);
+		}
+
+		$dom = new DOMDocument;
+		$dom->loadXML($export->asXML());
+		$dom->formatOutput = true;
+
+		return $dom->saveXML();
+	}
+}

--- a/com_languagepack/site/views/export/view.xml.php
+++ b/com_languagepack/site/views/export/view.xml.php
@@ -10,6 +10,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\MVC\View\HtmlView;
+use Joomla\CMS\Language\Text;
 
 /**
  * Export view class
@@ -44,7 +45,7 @@ class LanguagepackViewExport extends HtmlView
 		elseif (!$exportData || !isset($exportData['total'])
 			|| !$exportData['total'])
 		{
-			echo $this->renderXmlError(['No Data Found']);
+			echo $this->renderXmlError([Text::_('COM_LANGUAGE_PACK_EXPORT_NO_DATA_FOUND')]);
 
 			return;
 		}

--- a/com_languagepack/site/views/export/view.xml.php
+++ b/com_languagepack/site/views/export/view.xml.php
@@ -39,7 +39,7 @@ class LanguagepackViewExport extends HtmlView
 		{
 			throw new Exception(implode("\n", $errors), 500);
 		}
-		elseif (!$exportData)
+		elseif (!$exportData || !isset($exportData['total']) || !$exportData['total'])
 		{
 			throw new Exception('No Data Found', 500);
 		}

--- a/com_languagepack/site/views/export/view.xml.php
+++ b/com_languagepack/site/views/export/view.xml.php
@@ -57,7 +57,8 @@ class LanguagepackViewExport extends HtmlView
 		);
 
 		// This document should always be downloaded
-		$this->document->setDownload(true);
+		// not sure what is the best choice here (lets see)
+		// $this->document->setDownload(true);
 
 		// Set the document name
 		if ($languageCode)


### PR DESCRIPTION
Based on @wilsonge code found here https://github.com/joomla/downloads.joomla.org/pull/246

To test:
https://downloads2.sandbox.joomla.org/index.php?option=com_languagepack&view=export&format=xml&cms_version=15
https://downloads2.sandbox.joomla.org/index.php?option=com_languagepack&view=export&format=xml&cms_version=15&language_code=af-ZA